### PR TITLE
fix Common module docs

### DIFF
--- a/src/Monocle/Common.elm
+++ b/src/Monocle/Common.elm
@@ -20,7 +20,7 @@ import Monocle.Optional as Optional exposing (Optional)
 
 {-| Convenient infix operator for composing optionals.
 
-   .getOption (maybe => array 2) (Just [10..15])
+   .getOption (maybe => array 2) (Just <| Array.fromList [ 10, 11, 12, 13 ])
    > 12
 
 -}
@@ -43,10 +43,10 @@ maybe =
 
 {-| Step into an `Array` at the given index.
 
-    array.getOption 2 (Array.fromList [10..15])
+    .getOption (array 2) (Array.fromList [ 10, 11, 12, 13 ])
     > Just 12
 
-    array.getOption 8 (Array.fromList [10..15])
+    .getOption (array 8) (Array.fromList [ 10, 11, 12, 13 ])
     > Nothing
 -}
 array : Int -> Optional (Array a) a
@@ -58,10 +58,10 @@ array index =
 
 {-| Step into a `Dict` with the given key.
 
-    dict.getOption "Tom" (Dict.fromList [("Tom","Cat")])
+    .getOption (dict "Tom") (Dict.fromList [ ( "Tom", "Cat" ) ])
     > Just "Cat"
 
-    dict.getOption "Jerry" (Dict.fromList [("Tom","Cat")])
+    .getOption (dict "Jerry") (Dict.fromList [ ( "Tom", "Cat" ) ])
     > Nothing
 -}
 dict : comparable -> Optional (Dict comparable v) v
@@ -88,7 +88,7 @@ result =
 
 {-| Step into a record with an `id` key.
 
-    id.get {id = 1000, name = ...}
+    id.get { id = 1000, name = ... }
     > Just 1000
 
 Since records with an `id` field are incredible common, this is
@@ -104,7 +104,7 @@ id =
 
 {-| Step into the first element of a pair.
 
-    first.get ('a', 'b')
+    first.get ( 'a', 'b' )
     > Just 'a'
 -}
 first : Lens ( a, b ) a
@@ -116,7 +116,7 @@ first =
 
 {-| Step into the second element of a pair.
 
-    second.get ('a', 'b')
+    second.get ( 'a', 'b' )
     > Just 'b'
 -}
 second : Lens ( a, b ) b


### PR DESCRIPTION
Fixed docs for the `Common` module:
- replaced old range syntax with plain lists: `[10..15] -> [ 10, 11, 12, 13 ]`
- fixed `array` and `dict` calls:
  - `array.getOption 2` was actually `(array 2).getOption`
  - refactored to `.getOption (array 2)` for consistency with the `(=>)` example
- added spaces according to _elm-format_