### PR TITLE
Updating the version to 1.5.0 and correcting the (<|>) documentation

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.0",
+    "version": "1.5.0",
     "summary": "Library providing functional tools to manipulate complex records",
     "repository": "https://github.com/arturopala/elm-monocle.git",
     "license": "MIT",

--- a/src/Monocle/Common.elm
+++ b/src/Monocle/Common.elm
@@ -21,14 +21,19 @@ import Monocle.Optional as Optional exposing (Optional)
 
 {-| Convenient Infix operator for composing lenses.
     Allows to chain lens composition for deeply nested structures:
+
     fromAtoB : Lens A B
     fromAtoB = Lense .b (\a b -> { a | b = b })
+
     fromBtoC : Lens B C
     fromBtoC = Lense .c (\b c -> { b | c = c })
+
     fromCtoD : Lens C D
     fromCtoD = Lense .d (\c d -> { c | d = d })
+
     fromDtoE : Lens D E
     fromDtoE = Lense .e (\d e -> { d | e = e })
+
     fromAtoE : Lens A E
     fromAtoE = fromAtoB <|> fromBtoC <|> fromCtoD <|> fromDtoE
 


### PR DESCRIPTION
(previous doc read badly on the documentation site)