### PR TITLE
removing specs for operators (not allowed in elm 0.19)

### DIFF
--- a/tests/CommonSpec.elm
+++ b/tests/CommonSpec.elm
@@ -3,19 +3,16 @@ module CommonSpec exposing (..)
 import Test exposing (..)
 import Expect
 import Fuzz exposing (int, tuple, string, char)
-import String
 import Dict
 import Maybe
 import Array
-import Monocle.Lens exposing (Lens)
-import Monocle.Common exposing (dict, (<|>), (=>), (=|>), maybe, array, list, listToArray, id)
+import Monocle.Common exposing (dict, maybe, array, list, listToArray, id)
 
 
 all : Test
 all =
     describe "A Common specification"
         [ test_maybe
-        , test_compose_lens
         , test_array_just
         , test_array_nothing
         , test_list_just
@@ -24,30 +21,7 @@ all =
         , test_list_to_array_reverse_get
         , test_dict_empty
         , test_dict_list
-        , test_infix_compose_optionals
-        , test_infix_compose_optional_with_lens
         ]
-
-
-test_compose_lens : Test
-test_compose_lens =
-    let
-        fromAtoB =
-            Lens .b (\b a -> { a | b = b })
-
-        fromBtoC =
-            Lens .c (\c b -> { b | c = c })
-
-        fromCtoD =
-            Lens .d (\d c -> { c | d = d })
-
-        test d =
-            { b = { c = { d = d + 1 } } }
-                |> .set (fromAtoB <|> fromBtoC <|> fromCtoD) d
-                |> .get (fromAtoB <|> fromBtoC <|> fromCtoD)
-                |> Expect.equal d
-    in
-        fuzz int "Common.<|> should compose lenses together" test
 
 
 test_maybe : Test
@@ -135,21 +109,3 @@ test_dict_list =
             .getOption opt (Dict.fromList [ ( "Tom", s ), ( "Alice", "Rabbit" ) ]) |> Expect.equal (Just s)
     in
         fuzz string "Common.dict should set and get value by key (preloaded dict)" test
-
-
-test_infix_compose_optionals : Test
-test_infix_compose_optionals =
-    let
-        test i =
-            .getOption (maybe => array 2) (Just <| Array.fromList [ 10, 11, i, 13 ]) |> Expect.equal (Just i)
-    in
-        fuzz int "Common.=> should compose 2 Optionals" test
-
-
-test_infix_compose_optional_with_lens : Test
-test_infix_compose_optional_with_lens =
-    let
-        test i =
-            .getOption (maybe =|> id) (Just { id = i }) |> Expect.equal (Just i)
-    in
-        fuzz int "Common.=|> should compose Optional with Lens" test


### PR DESCRIPTION
A quick one to make the tests pass again.