### PR TITLE
update Prism examples to elm 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ A Prism is a tool which optionally converts elements of type A into elements of 
 ```elm
     string2IntPrism : Prism String Int
     string2IntPrism =
-        Prism (String.toInt >> Result.toMaybe) toString
+        Prism String.toInt String.fromInt
 
     string2IntPrism.getOption "17896" == Just 17896
     string2IntPrism.getOption "1a896" == Nothing
@@ -208,7 +208,7 @@ A Optional is a weaker Lens and a weaker Prism.
         Optional .region (\b a -> { a | region = Just b })
 
     string2IntPrism : Prism String Int
-    string2IntPrism = Prism (String.toInt >> Result.toMaybe) toString
+    string2IntPrism = Prism String.toInt String.fromInt
 
     addressRegionIntOptional: Optional Address Int
     addressRegionIntOptional =

--- a/src/Monocle/Optional.elm
+++ b/src/Monocle/Optional.elm
@@ -58,7 +58,7 @@ type alias Optional a b =
 
     string2IntPrism : Prism String Int
     string2IntPrism =
-        Prism (String.toInt >> Result.toMaybe) toString
+        Prism String.toInt String.fromInt
 
     addressRegionIntOptional : Optional Address Int
     addressRegionIntOptional =
@@ -192,7 +192,7 @@ modify3 opt1 opt2 opt3 fx =
 
     string2IntPrism : Prism String Int
     string2IntPrism =
-        Prism (String.toInt >> Result.toMaybe) toString
+        Prism String.toInt String.fromInt
 
     stringIntOptional : Optional String Int
     stringIntOptional =

--- a/src/Monocle/Prism.elm
+++ b/src/Monocle/Prism.elm
@@ -16,7 +16,7 @@ module Monocle.Prism exposing
 
     string2IntPrism : Prism String Int
     string2IntPrism =
-        Prism (String.toInt >> Result.toMaybe) toString
+        Prism String.toInt String.fromInt
 
     string2IntPrism.getOption "17896" == Just 17896
     string2IntPrism.getOption "1a896" == Nothing


### PR DESCRIPTION
Update some examples to elm 0.19

`String.toInt` returns already a `Maybe.Int`

`String.fromInt` should be used instead of `toString`