### PR TITLE
correct spelling

### DIFF
--- a/src/Monocle/Compose.elm
+++ b/src/Monocle/Compose.elm
@@ -12,7 +12,7 @@ Using these allow to compose an "outer" optic with an "inner" other optic.
 
 Optics in functional programming languages that support typeclasses can be
 expressed as functions that compose through the composition operator (just like
-any other functions) ; in Elm (plus typclasses), it would look like this:
+any other functions) ; in Elm (plus typeclasses), it would look like this:
 
     lensAtoB >> lensBtoC >> lensCtoD == lensAtoD
 

--- a/src/Monocle/Lens.elm
+++ b/src/Monocle/Lens.elm
@@ -80,7 +80,7 @@ compose outer inner =
 {-| Modifies given function `(b -> b)` to be `(a -> a)` using `Lens a b`
 
     addressStreetNameLens = Lens Address String
-    fx streetName = String.reverse streeName
+    fx streetName = String.reverse streetName
     fx2 = Lens.modify addressStreetNameLens fx
     fx2 {streetName="abcdef"} == {streetName="fedcba"}
 

--- a/tests/ComposeSpec.elm
+++ b/tests/ComposeSpec.elm
@@ -240,12 +240,12 @@ test_lensWithLens =
         lensPerson2StreetAddress =
             Lens .streetAddress (\streetAddress person -> { person | streetAddress = streetAddress })
 
-        lensStreetAdress2City =
+        lensStreetAddress2City =
             Lens .city (\city streetAddress -> { streetAddress | city = city })
 
         lensPerson2StreetAddressCity =
             lensPerson2StreetAddress
-                |> Compose.lensWithLens lensStreetAdress2City
+                |> Compose.lensWithLens lensStreetAddress2City
 
         personify ( name, street, city ) =
             { name = name


### PR DESCRIPTION
Corrected spelling mistakes: `typclasses`, `streeName` and `lensStreetAdress2City`